### PR TITLE
chore: added CI / CD for publishing every new release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
+      - run: npm install
+      
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Overview
This PR adds a GitHub Actions workflow to automatically publish the package to npm upon a new release.

### Changes
- Introduced a CI/CD workflow that runs on `ubuntu-latest` and installs dependencies before publishing the package.

### Secrets Requirement
The `NPM_TOKEN` secret must be added to the repository settings to enable secure authentication with npm for publishing.