### PR TITLE
chore: remove hardcoded cost models and update blaze and utxorpc dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@utxorpc/blaze-provider",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@utxorpc/blaze-provider",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "ISC",
       "dependencies": {
-        "@blaze-cardano/core": "^0.5.2",
-        "@blaze-cardano/query": "^0.3.2",
-        "@blaze-cardano/sdk": "^0.2.12",
+        "@blaze-cardano/core": "^0.6.1",
+        "@blaze-cardano/query": "^0.3.5",
+        "@blaze-cardano/sdk": "^0.2.19",
         "@blaze-cardano/tsconfig": "^0.0.3",
-        "@utxorpc/sdk": "^0.6.5",
-        "@utxorpc/spec": "^0.15.0",
+        "@utxorpc/sdk": "^0.6.6",
+        "@utxorpc/spec": "^0.16.0",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -46,17 +46,17 @@
       }
     },
     "node_modules/@blaze-cardano/core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/core/-/core-0.5.2.tgz",
-      "integrity": "sha512-3jy6b4REQCy+GjM2+szJwsQmpTpHfloFOCySnUqkinu8qdf3gSzDDVonId3ZDkZNq2Q5eP9Xg+VjRJyjsfWJ3g==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/core/-/core-0.6.1.tgz",
+      "integrity": "sha512-0z14yhmL+FmtC00et1UkbqHMTTC2xkfL2+5Fd2zmUEEP27uJsJNvimPv9slvaSldiYymKVCZiibdXRr9tzciUw==",
       "dependencies": {
-        "@cardano-sdk/core": "^0.40.1",
-        "@cardano-sdk/crypto": "^0.1.30",
+        "@cardano-sdk/core": "^0.45.0",
+        "@cardano-sdk/crypto": "^0.1.32",
         "@cardano-sdk/util": "^0.15.5",
-        "@noble/curves": "^1.6.0",
-        "@noble/ed25519": "^2.1.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/bip39": "^1.4.0",
+        "@noble/curves": "^1.8.1",
+        "@noble/ed25519": "^2.2.3",
+        "@noble/hashes": "^1.7.1",
+        "@scure/bip39": "^1.5.4",
         "blakejs": "^1.2.1"
       }
     },
@@ -76,11 +76,11 @@
       }
     },
     "node_modules/@blaze-cardano/query": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/query/-/query-0.3.2.tgz",
-      "integrity": "sha512-KiIMQY7mpGcEVj4d9ImEyij2ZEum3sgmuj/2tTYk8w0Tf0aQE3rTQkh0wX3X3yQAJKyteRIm6mieMUVyslgo3A==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/query/-/query-0.3.5.tgz",
+      "integrity": "sha512-ol/plJzalE6MDnMyFykiOOxwBi+uvz/TE20j7vDKrcPXuStW1oqUsiLNwVk7H1esmvE+687ZQe28BKd/1HoNLQ==",
       "dependencies": {
-        "@blaze-cardano/core": "0.5.2",
+        "@blaze-cardano/core": "0.6.1",
         "@blaze-cardano/jest-config": "0.0.1",
         "@blaze-cardano/ogmios": "0.0.7",
         "@cardano-ogmios/schema": "^6.6.1",
@@ -88,15 +88,15 @@
       }
     },
     "node_modules/@blaze-cardano/sdk": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/sdk/-/sdk-0.2.12.tgz",
-      "integrity": "sha512-OMu5DJW9Lzjl4N63tG+9umcISysI54TWTHb80RTyY3kK9R7L12sFokfbZ44WBtmgHtOpKt+HHVdwFxSF/mISlg==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/sdk/-/sdk-0.2.19.tgz",
+      "integrity": "sha512-v3xPIvHT/DLB8F/lNRcJZ/6gr7iJdfarrhVEmkZwu7EQKKQPHK0aJhOWBI8n3E7HUZMsKp4YFc1l/UvyOcx+mw==",
       "dependencies": {
-        "@blaze-cardano/core": "0.5.2",
-        "@blaze-cardano/query": "0.3.2",
-        "@blaze-cardano/tx": "0.8.4",
-        "@blaze-cardano/uplc": "0.1.38",
-        "@blaze-cardano/wallet": "0.3.2"
+        "@blaze-cardano/core": "0.6.1",
+        "@blaze-cardano/query": "0.3.5",
+        "@blaze-cardano/tx": "0.10.3",
+        "@blaze-cardano/uplc": "0.2.3",
+        "@blaze-cardano/wallet": "0.3.8"
       }
     },
     "node_modules/@blaze-cardano/tsconfig": {
@@ -106,42 +106,42 @@
       "license": "MIT"
     },
     "node_modules/@blaze-cardano/tx": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/tx/-/tx-0.8.4.tgz",
-      "integrity": "sha512-Opi08Ht8fT3FzbHg4Z7um1AD8/jl+45irbCNZqVFnxQuPDX/4PQ/ii5pw/u0Sqb3hXLOn74cSPDYqRA3RjQBzw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/tx/-/tx-0.10.3.tgz",
+      "integrity": "sha512-Y8ZwR3RTBKJlEmTTGZ9zhBXI35nCk5Q9yAFpzP/xvDYj96+IGmmQBxhxfAHTbMSu0G+UfVi4sLD00j4tMJe+Yw==",
       "dependencies": {
-        "@blaze-cardano/core": "0.5.2",
-        "@blaze-cardano/vm": "0.1.5"
+        "@blaze-cardano/core": "0.6.1",
+        "@blaze-cardano/vm": "0.1.7"
       }
     },
     "node_modules/@blaze-cardano/uplc": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/uplc/-/uplc-0.1.38.tgz",
-      "integrity": "sha512-khlzYchO7oWJxba5QHwrLBJPyK1MI+HWqdP5ENyzCAXqsOX5hkBJYb7H2bDUlYv6/BDha093eKSOwozjkKmfZQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/uplc/-/uplc-0.2.3.tgz",
+      "integrity": "sha512-KIu72qHcY1tLSUERRRSj7A5yiKP34Zmt8BJxYSBHCzStKnRpzTPq4yL7SQlWcFnQu+BBZ7wSXmfN30B1K0frrQ==",
       "dependencies": {
-        "@blaze-cardano/core": "0.5.2",
-        "@blaze-cardano/tx": "0.8.4",
+        "@blaze-cardano/core": "0.6.1",
+        "@blaze-cardano/tx": "0.10.3",
         "hex-encoding": "^2.0.2"
       }
     },
     "node_modules/@blaze-cardano/vm": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/vm/-/vm-0.1.5.tgz",
-      "integrity": "sha512-jYMJ8vI7yc8zdLf5vwGySKD/bwbnDNfIlqE6tCw+y07esiWWxwg8WjyzMAx3/ZV0BwdQsYp0hsRVPf3Ui0Gu7g==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/vm/-/vm-0.1.7.tgz",
+      "integrity": "sha512-hdvum78R3voRkIGVbC68U/o2+EMMC1EqFVIojrVFuSkY8dNQLze3DbfZ39ctDxD627p+Uei9QupZ+xHfvNWuAQ==",
       "dependencies": {
-        "@blaze-cardano/core": "0.5.2",
+        "@blaze-cardano/core": "0.6.1",
         "uplc-node": "github:jpg-store/uplc-node#fd3f2c6dc2629092e3eb37eeac48587b5eceeffb"
       }
     },
     "node_modules/@blaze-cardano/wallet": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/wallet/-/wallet-0.3.2.tgz",
-      "integrity": "sha512-PQtE13A/RohFvrtNO6WyyLWnZOoyChW0yBwYdz5lcFsSBnqra2gGNAednJV58yqLaqyN8AJCLqMkNfOPqDRXwA==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/wallet/-/wallet-0.3.8.tgz",
+      "integrity": "sha512-o0tn/ksLu58dEKOcA5cfvx2d8b5W+Il0Tw6saV1Q5wHDLCZK+r9lda26883yWaY2hP+LHUim+opTm35U+1zQHA==",
       "dependencies": {
-        "@blaze-cardano/core": "0.5.2",
+        "@blaze-cardano/core": "0.6.1",
         "@blaze-cardano/jest-config": "0.0.1",
-        "@blaze-cardano/query": "0.3.2",
-        "@blaze-cardano/tx": "0.8.4",
+        "@blaze-cardano/query": "0.3.5",
+        "@blaze-cardano/tx": "0.10.3",
         "@emurgo/cardano-message-signing-browser": "^1.1.0",
         "@emurgo/cardano-message-signing-nodejs": "^1.1.0"
       }
@@ -153,12 +153,12 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cardano-ogmios/client": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@cardano-ogmios/client/-/client-6.5.0.tgz",
-      "integrity": "sha512-hdianZyQ7r/mr0bfOQ5cZkeClF4hs1rz8R0JBwn+S/Iv0ElfcvhuOamy8whxc2n+rFnfVIyHoSoBHRMibyWKxw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@cardano-ogmios/client/-/client-6.9.0.tgz",
+      "integrity": "sha512-IsoUVsaMXiYyhWrdVKYOA5PDlX0EZ2gaq4lfk4JelRw6mcWVxemUrMaU2ndvugO9LQ3SCM1nESPgMIU0xe5FWw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@cardano-ogmios/schema": "6.5.0",
+        "@cardano-ogmios/schema": "6.9.0",
         "@cardanosolutions/json-bigint": "^1.0.1",
         "@types/json-bigint": "^1.0.1",
         "bech32": "^2.0.0",
@@ -169,15 +169,6 @@
         "ts-custom-error": "^3.2.0",
         "ws": "^7.5.10"
       },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@cardano-ogmios/client/node_modules/@cardano-ogmios/schema": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@cardano-ogmios/schema/-/schema-6.5.0.tgz",
-      "integrity": "sha512-tE2LvqfZ1SNBm4C6H/VITtFQ/zOJ8diGuHFPe30Pvg4hQzmD/1ekGCb73MJkcKy2WGpIRjnk/uwAzczc7Y320A==",
-      "license": "MPL-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -222,15 +213,15 @@
       }
     },
     "node_modules/@cardano-sdk/core": {
-      "version": "0.40.1",
-      "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.40.1.tgz",
-      "integrity": "sha512-QMJDhR/z95/L/9mkHnzKA+q3FsktBl1M/e4keAiwv9lE4kLVJmlP6fvrnrOB0oGg6wdk//ZTS6twa9JTtN7D5w==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.45.0.tgz",
+      "integrity": "sha512-7bRpbbwsZF5XIGy4Tsm4KErMEnEhTsPjgvjgGDUO+oacXZkdxJRckcsiI7DPRmmJBm/7tAyHUirfXiGw3Gg9DQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@biglup/is-cid": "^1.0.3",
-        "@cardano-ogmios/client": "6.5.0",
-        "@cardano-ogmios/schema": "6.5.0",
-        "@cardano-sdk/crypto": "~0.1.30",
+        "@cardano-ogmios/client": "6.9.0",
+        "@cardano-ogmios/schema": "6.9.0",
+        "@cardano-sdk/crypto": "~0.2.0",
         "@cardano-sdk/util": "~0.15.5",
         "@foxglove/crc": "^0.0.3",
         "@scure/base": "^1.1.1",
@@ -253,19 +244,46 @@
         }
       }
     },
-    "node_modules/@cardano-sdk/core/node_modules/@cardano-ogmios/schema": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@cardano-ogmios/schema/-/schema-6.5.0.tgz",
-      "integrity": "sha512-tE2LvqfZ1SNBm4C6H/VITtFQ/zOJ8diGuHFPe30Pvg4hQzmD/1ekGCb73MJkcKy2WGpIRjnk/uwAzczc7Y320A==",
-      "license": "MPL-2.0",
+    "node_modules/@cardano-sdk/core/node_modules/@cardano-sdk/crypto": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.2.0.tgz",
+      "integrity": "sha512-+PYHztXp9Us7tDuZj+x2r+VVGjTDdhS8m5ONiYg4t3Ja8sQjjOTCEST8VLAXuamrl77xwDB3nNRHsgRe9NM+Sw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cardano-sdk/util": "~0.15.5",
+        "blake2b": "^2.1.4",
+        "i": "^0.3.7",
+        "libsodium-wrappers-sumo": "^0.7.5",
+        "lodash": "^4.17.21",
+        "npm": "^9.3.0",
+        "pbkdf2": "^3.1.2",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4"
+      },
       "engines": {
-        "node": ">=14"
+        "node": ">=16.20.2"
+      },
+      "peerDependencies": {
+        "@dcspark/cardano-multiplatform-lib-asmjs": "^3.1.1",
+        "@dcspark/cardano-multiplatform-lib-browser": "^3.1.1",
+        "@dcspark/cardano-multiplatform-lib-nodejs": "^3.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@dcspark/cardano-multiplatform-lib-asmjs": {
+          "optional": true
+        },
+        "@dcspark/cardano-multiplatform-lib-browser": {
+          "optional": true
+        },
+        "@dcspark/cardano-multiplatform-lib-nodejs": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cardano-sdk/crypto": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.1.30.tgz",
-      "integrity": "sha512-xUJSF+OWL8z1t/cnjRlYVMIC2zlk3cYazn6/+bEyvXHv9+XyPbgZK44iOiJryJcgsaG7ibzJXaOw/DWeS1dwSg==",
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.1.32.tgz",
+      "integrity": "sha512-RCKFvkzD32QpKQ0jULADVRNmfBNkCwiZl2nlFbkZ3aCrfIex+6/2CizoagJ161fA7lL5/HGuzWfjOg3GX2ax6w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cardano-sdk/util": "~0.15.5",
@@ -998,7 +1016,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1096,9 +1113,9 @@
       }
     },
     "node_modules/@multiformats/multiaddr": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.3.1.tgz",
-      "integrity": "sha512-yoGODQY4nIj41ENJClucS8FtBoe8w682bzbKldEQr9lSlfdHqAsRC+vpJAOBpiMwPps1tHua4kxrDmvprdhoDQ==",
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.3.4.tgz",
+      "integrity": "sha512-R4pEEUyWGrRo16TSflz80Yr6XNbPirix1pfPqDLXsDZ4aaIrhZ7cez9jnyRQgci6DuuqSyZAdJKV6SdxpZ7Oiw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
@@ -1110,12 +1127,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
-      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.5.0"
+        "@noble/hashes": "1.7.1"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1125,18 +1142,18 @@
       }
     },
     "node_modules/@noble/ed25519": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.1.0.tgz",
-      "integrity": "sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.2.3.tgz",
+      "integrity": "sha512-iHV8eI2mRcUmOx159QNrU8vTpQ/Xm70yJ2cTk3Trc86++02usfqFoNl6x0p3JN81ZDS/1gx6xiK0OwrgqCT43g==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1187,7 +1204,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1419,22 +1435,22 @@
       ]
     },
     "node_modules/@scure/base": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.8.tgz",
-      "integrity": "sha512-6CyAclxj3Nb0XT7GHK6K4zK6k2xJm6E4Ft0Ohjt4WgegiFUHEtFb2CGzmPmGBwoIhrLsqNLYfLr04Y1GePrzZg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
-      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.5.0",
-        "@scure/base": "~1.1.8"
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.4"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1463,12 +1479,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "version": "22.10.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.10.tgz",
+      "integrity": "sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.8"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1666,9 +1682,9 @@
       }
     },
     "node_modules/@utxorpc/sdk": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@utxorpc/sdk/-/sdk-0.6.5.tgz",
-      "integrity": "sha512-8Et+ZTbTPlOpUMDmx5jjLLtmWJd891Wpcbp+LOkB17ycISWHEAl3EpNcNEZPAwWHxvDEUp7ogM/+kM5+583nUg==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@utxorpc/sdk/-/sdk-0.6.6.tgz",
+      "integrity": "sha512-rg984YH7i5SMEPQ23iR90uTgV6jjfiPtXaZJad99GI8YiLPsg7o1wSLnBayQMC79RlUDF8jvuIWjneMHM5AWVA==",
       "license": "MIT",
       "dependencies": {
         "@connectrpc/connect": "1.4",
@@ -1678,10 +1694,22 @@
         "buffer": "^6.0.3"
       }
     },
-    "node_modules/@utxorpc/spec": {
+    "node_modules/@utxorpc/sdk/node_modules/@utxorpc/spec": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@utxorpc/spec/-/spec-0.15.0.tgz",
       "integrity": "sha512-3JEblLJSBPLorExUSbuyL3giRGhpl6XxZkS/B+1hp4NzRK+rZdkDkeIwaEK/FgSNx/MVzXSRH7L1XVQRSTTlcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@utxorpc/spec": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@utxorpc/spec/-/spec-0.16.0.tgz",
+      "integrity": "sha512-EK2M0TBp14MrRCYDuFeJ+bAS39RxxLLh+CD08h/YvAgxSv/4ZOBCf1/sxHAGCBGGndB4heZYFeuQ+i1i8vP5lw==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0"
@@ -1738,7 +1766,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1751,7 +1778,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1813,16 +1839,15 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
       "license": "Apache-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -1903,7 +1928,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1973,16 +1997,44 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2004,7 +2056,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2020,7 +2071,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2057,20 +2107,22 @@
       }
     },
     "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2083,7 +2135,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -2140,19 +2191,18 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.12"
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2229,28 +2279,37 @@
         "node": ">=6"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -2260,6 +2319,18 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -2676,7 +2747,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -2693,7 +2763,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2736,22 +2805,40 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2771,7 +2858,6 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -2835,12 +2921,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2856,7 +2942,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2873,22 +2958,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2926,29 +2999,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/hash-base/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/hash-base/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/hashlru": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
@@ -2968,12 +3018,13 @@
       }
     },
     "node_modules/hex-encoding": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hex-encoding/-/hex-encoding-2.0.2.tgz",
-      "integrity": "sha512-NhclxbCmF1NTU9mE0GYEkUrFX5VvnfiHrzcqGbsQJcLT33rE/yqBB+U1bHDuLk86AQyN/hsr+Q/sX3jRxmarhg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hex-encoding/-/hex-encoding-2.0.3.tgz",
+      "integrity": "sha512-sSmMo4ij2Vejht+5UkzuzNGiYgIWTSUw0GQqxHIQXsuuXB1ozYnjCZJZ/nwWNYRoU8+92Dp736wqxmiAN6/fcw==",
+      "license": "MIT",
       "dependencies": {
-        "node-buffer-encoding": "^1.0.1",
-        "uint8-encoding": "^2.0.0"
+        "node-buffer-encoding": "^1.0.3",
+        "uint8-encoding": "^2.0.1"
       }
     },
     "node_modules/human-signals": {
@@ -3078,13 +3129,13 @@
       }
     },
     "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3132,19 +3183,21 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3185,6 +3238,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3199,12 +3270,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3217,7 +3288,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iso-url": {
@@ -3242,7 +3312,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -3405,8 +3474,16 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -3464,7 +3541,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -3480,7 +3556,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3490,7 +3565,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multiformats": {
@@ -3518,9 +3592,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -3542,9 +3616,10 @@
       "dev": true
     },
     "node_modules/node-buffer-encoding": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/node-buffer-encoding/-/node-buffer-encoding-1.0.2.tgz",
-      "integrity": "sha512-v2QFjf04xWb5Q7cyzbi8qEwe2vw2xJBXT7+pMOLA02+KJZlcJ/6syFYiH96ClXKfOG/kyBeysAuewJ7zfAUYKQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/node-buffer-encoding/-/node-buffer-encoding-1.0.3.tgz",
+      "integrity": "sha512-9hJZNChhQoCN1rCFScJiEwtzvWEJw2wSnu2nhDLD/YOYl1Ce8GbtnorsnjwwjpSk4sWE7zSp2etX6j7+bO7fVA==",
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -3577,9 +3652,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "9.9.3",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.9.3.tgz",
-      "integrity": "sha512-Z1l+rcQ5kYb17F3hHtO601arEpvdRYnCLtg8xo3AGtyj3IthwaraEOexI9903uANkifFbqHC8hT53KIrozWg8A==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.9.4.tgz",
+      "integrity": "sha512-NzcQiLpqDuLhavdyJ2J3tGJ/ni/ebcqHVFZkv1C4/6lblraUPbPgCJ4Vhb4oa3FFhRa2Yj9gA58jGH/ztKueNQ==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -3681,7 +3756,7 @@
         "fs-minipass": "^3.0.3",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^6.1.1",
+        "hosted-git-info": "^6.1.3",
         "ini": "^4.1.1",
         "init-package-json": "^5.0.0",
         "is-cidr": "^4.0.2",
@@ -3724,7 +3799,7 @@
         "spdx-expression-parse": "^3.0.1",
         "ssri": "^10.0.5",
         "supports-color": "^9.4.0",
-        "tar": "^6.2.0",
+        "tar": "^6.2.1",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
@@ -4437,7 +4512,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
-      "version": "7.0.3",
+      "version": "7.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4475,11 +4550,11 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.3.4",
+      "version": "4.3.7",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -4489,11 +4564,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/npm/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.4",
@@ -4664,7 +4734,7 @@
       }
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "6.1.1",
+      "version": "6.1.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6348,7 +6418,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6692,9 +6762,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
-      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
+      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
@@ -6708,9 +6778,9 @@
       }
     },
     "node_modules/p-timeout": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.3.tgz",
-      "integrity": "sha512-UJUyfKbwvr/uZSV6btANfb+0t/mOhKV/KXcCUTp8FcQI+v/0d+wXqH4htrW0E4rR6WiEO/EPvUFiV9D5OI4vlw==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -6723,7 +6793,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -6751,7 +6820,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6761,7 +6829,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -6943,6 +7010,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7075,11 +7156,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7148,7 +7245,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7161,7 +7257,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7232,11 +7327,19 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -7255,7 +7358,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7270,7 +7372,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7280,14 +7381,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7300,7 +7399,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -7317,7 +7415,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7330,7 +7427,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7385,7 +7481,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7396,8 +7491,7 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -7480,9 +7574,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/ts-log": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.5.tgz",
-      "integrity": "sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.7.tgz",
+      "integrity": "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==",
       "license": "MIT"
     },
     "node_modules/tslib": {
@@ -7605,9 +7699,10 @@
       }
     },
     "node_modules/uint8-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/uint8-encoding/-/uint8-encoding-2.0.0.tgz",
-      "integrity": "sha512-MQcY+mEuLoHBqAawasWrFbZx1SqUoFU/wVYNGO6lsIxczeO+cNjA1djYHQM3GWU3SaEhKTfG3Z5cE2r+zR6tNw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uint8-encoding/-/uint8-encoding-2.0.1.tgz",
+      "integrity": "sha512-xZAjZ+3OvrDtjFLLgojrLmG6T0YwZEo0OTyqCBxFjlFimIKnLtFqyYk6z/jDOUlJFJE52Srtrv4W4x7t4Cn/dA==",
+      "license": "MIT"
     },
     "node_modules/uint8-varint": {
       "version": "2.0.4",
@@ -7650,9 +7745,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "license": "MIT"
     },
     "node_modules/uplc-node": {
@@ -7721,7 +7816,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7734,15 +7828,16 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -7765,7 +7860,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -7784,7 +7878,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7802,7 +7895,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7812,7 +7904,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -7828,14 +7919,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7850,7 +7939,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@blaze-cardano/core": "^0.5.2",
-    "@blaze-cardano/query": "^0.3.2",
-    "@blaze-cardano/sdk": "^0.2.12",
+    "@blaze-cardano/core": "^0.6.1",
+    "@blaze-cardano/query": "^0.3.5",
+    "@blaze-cardano/sdk": "^0.2.19",
     "@blaze-cardano/tsconfig": "^0.0.3",
-    "@utxorpc/sdk": "^0.6.5",
-    "@utxorpc/spec": "^0.15.0",
+    "@utxorpc/sdk": "^0.6.6",
+    "@utxorpc/spec": "^0.16.0",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/src/u5c.ts
+++ b/src/u5c.ts
@@ -229,7 +229,7 @@ export class U5C extends Provider {
     tx.body().inputs().setValues(finalInputs);
     tx.body().setOutputs(finalOutputs);
     const unevaluatedRedeemers = tx.witnessSet().redeemers()?.values()!;
-    
+
     const report = await this.submitClient.evalTx(fromHex(tx.toCbor()));
     const evalResult = report.report[0].chain.value?.redeemers!;
 
@@ -243,9 +243,9 @@ export class U5C extends Provider {
           BigInt(evalResult[i].exUnits?.memory!),
           BigInt(evalResult[i].exUnits?.steps!)
         )
-      ))
+      ));
     }
-    
+
     const finalRedeemers = Redeemers.fromCore([]);
     finalRedeemers.setValues(redeemers);
     return finalRedeemers;
@@ -358,27 +358,11 @@ export class U5C extends Provider {
         )
         .set(
           PlutusLanguageVersion.V3,
-          [100788, 420, 1, 1, 1000, 173, 0, 1, 1000, 59957, 4, 1, 11183, 32, 201305, 8356, 4,
-            16000, 100, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 100, 100,
-            16000, 100, 94375, 32, 132994, 32, 61462, 4, 72010, 178, 0, 1, 22151, 32, 91189,
-            769, 4, 2, 85848, 123203, 7305, -900, 1716, 549, 57, 85848, 0, 1, 1, 1000, 42921,
-            4, 2, 24548, 29498, 38, 1, 898148, 27279, 1, 51775, 558, 1, 39184, 1000, 60594, 1,
-            141895, 32, 83150, 32, 15299, 32, 76049, 1, 13169, 4, 22100, 10, 28999, 74, 1,
-            28999, 74, 1, 43285, 552, 1, 44749, 541, 1, 33852, 32, 68246, 32, 72362, 32, 7243,
-            32, 7391, 32, 11546, 32, 85848, 123203, 7305, -900, 1716, 549, 57, 85848, 0, 1,
-            90434, 519, 0, 1, 74433, 32, 85848, 123203, 7305, -900, 1716, 549, 57, 85848, 0, 1,
-            1, 85848, 123203, 7305, -900, 1716, 549, 57, 85848, 0, 1, 955506, 213312, 0, 2,
-            270652, 22588, 4, 1457325, 64566, 4, 20467, 1, 4, 0, 141992, 32, 100788, 420, 1, 1,
-            81663, 32, 59498, 32, 20142, 32, 24588, 32, 20744, 32, 25933, 32, 24623, 32,
-            43053543, 10, 53384111, 14333, 10, 43574283, 26308, 10, 16000, 100, 16000, 100,
-            962335, 18, 2780678, 6, 442008, 1, 52538055, 3756, 18, 267929, 18, 76433006, 8868,
-            18, 52948122, 18, 1995836, 36, 3227919, 12, 901022, 1, 166917843, 4307, 36, 284546,
-            36, 158221314, 26549, 36, 74698472, 36, 333849714, 1, 254006273, 72, 2174038, 72,
-            2261318, 64571, 4, 207616, 8310, 4, 1293828, 28716, 63, 0, 1, 1006041, 43623, 251,
-            0, 1, 100181, 726, 719, 0, 1, 100181, 726, 719, 0, 1, 100181, 726, 719, 0, 1,
-            107878, 680, 0, 1, 95336, 1, 281145, 18848, 0, 1, 180194, 159, 1, 1, 158519, 8942,
-            0, 1, 159378, 8813, 0, 1, 107490, 3298, 1, 106057, 655, 1, 1964219, 24520, 3]
-          ,
+          rpcPParams.costModels?.plutusV3?.values.map((v) =>
+            Number(v.toString()),
+          ) ??
+            hardCodedProtocolParams.costModels.get(PlutusLanguageVersion.V3) ??
+            [],
         ),
       maxBlockBodySize: Number(rpcPParams.maxBlockBodySize),
       maxBlockHeaderSize: Number(rpcPParams.maxBlockHeaderSize),
@@ -395,9 +379,9 @@ export class U5C extends Provider {
       stakeKeyDeposit: Number(rpcPParams.stakeKeyDeposit),
       poolRetirementEpochBound: Number(rpcPParams.poolRetirementEpochBound),
       desiredNumberOfPools: Number(rpcPParams.desiredNumberOfPools),
-      poolInfluence: `${rpcPParams.poolInfluence?.numerator}/${rpcPParams.poolInfluence?.denominator}`,
-      monetaryExpansion: `${rpcPParams.monetaryExpansion?.numerator}/${rpcPParams.monetaryExpansion?.denominator}`,
-      treasuryExpansion: `${rpcPParams.treasuryExpansion?.numerator}/${rpcPParams.treasuryExpansion?.denominator}`,
+      poolInfluence: `${rpcPParams.poolInfluence?.numerator! / rpcPParams.poolInfluence?.denominator!}`,
+      monetaryExpansion: `${rpcPParams.monetaryExpansion?.numerator! / rpcPParams.monetaryExpansion?.denominator!}`,
+      treasuryExpansion: `${rpcPParams.treasuryExpansion?.numerator! / rpcPParams.treasuryExpansion?.denominator!}`,
       protocolVersion: {
         minor: Number(rpcPParams.protocolVersion?.minor),
         major: Number(rpcPParams.protocolVersion?.major),


### PR DESCRIPTION
This pr updates the following dependencies to the latest versions:
- @blaze-cardano-core
- @blaze-cardano-query
- @blaze-cardano-sdk
- @utxorpc/sdk
- @utxorpc/spec

This also removes the hardoced cost models, and adjusted the parsing for poolInfluence, monetary expansion and treasury expansion in u5c to core mapping