### PR TITLE
chore: update dependencies and enhance U5C class with slot conversion methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,22 +24,22 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@blaze-cardano/core": "^0.6.1",
-    "@blaze-cardano/query": "^0.3.5",
-    "@blaze-cardano/sdk": "^0.2.19",
+    "@blaze-cardano/core": "^0.6.4",
+    "@blaze-cardano/query": "^0.4.5",
+    "@blaze-cardano/sdk": "^0.2.32",
     "@blaze-cardano/tsconfig": "^0.0.3",
     "@utxorpc/sdk": "^0.6.7",
     "@utxorpc/spec": "^0.16.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
-    "@eslint/js": "^9.10.0",
-    "eslint": "^9.10.0",
-    "eslint-config-prettier": "^9.1.0",
-    "globals": "^15.9.0",
-    "prettier": "^3.3.3",
-    "tsup": "^8.2.4",
-    "typescript": "^5.5.4",
-    "typescript-eslint": "^8.4.0"
+    "@eslint/js": "^9.29.0",
+    "eslint": "^9.29.0",
+    "eslint-config-prettier": "^10.1.5",
+    "globals": "^16.2.0",
+    "prettier": "^3.6.1",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.35.0"
   }
 }

--- a/src/u5c.ts
+++ b/src/u5c.ts
@@ -417,7 +417,7 @@ export class U5C extends Provider {
         return SLOT_CONFIG_NETWORK.Preview;
       default:
         // Default to preprod for testnet
-        return SLOT_CONFIG_NETWORK.Preview;
+        return SLOT_CONFIG_NETWORK.Preprod;
     }
   }
 


### PR DESCRIPTION
- Updated dependencies to latest versions
- Implemented missing Provider interface methods (getSlotConfig, unixToSlot, slotToUnix) to ensure compatibility with @blaze-cardano/query v0.4.5